### PR TITLE
Fix: Acommodate new nps trailheads table format

### DIFF
--- a/hackjohn.py
+++ b/hackjohn.py
@@ -67,7 +67,9 @@ def get_trailhead_df():
         header=1,
         attrs={"id": "cs_idLayout2"},
         flavor="html5lib",
-        skiprows=1,  # skip report date row with one cell
+        # check table at nps trailheads site for irrelevant leading rows
+        # update skiprows value so first row is actual table header
+        skiprows=0,
         parse_dates=["Date"],
     )
     wide_df = wide_df.iloc[:, :6]


### PR DESCRIPTION
NPS has removed a leading row from the [Donohue Pass availability chart](https://www.nps.gov/yose/planyourvisit/fulltrailheads.htm#CP_JUMP_5529621).

This PR updates `skiprows` in `read_html` to 0 to reflect this change and adds a note in the comment. 
This could possibly be included in the readme instructions, for users who are able to identify leading rows in nps availability table. 

See: #7 ValueError "Date" is not in list