### PR TITLE
Update to work with new website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # hackjohn files
 hackjohn.log
 hackjohn-output.txt
+.cookies.pickle
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -3,31 +3,24 @@
 [![Hackjohn CI](https://github.com/dhimmel/hackjohn/workflows/Hackjohn%20CI/badge.svg?branch=master)](https://github.com/dhimmel/hackjohn/actions)
 
 This repository contains a Python script for monitoring Yosemite's [permit availability report](https://yosemite.org/planning-your-wilderness-permit/).
-Vacancies in this table indicate the availability of a southbound John Muir 
-Trail permit, available for immediate reservation by filling out the online 
-[permit request form](https://yosemite.org/yosemite-wilderness-permit-request-form/).
-This strategy enables securing a soutbound JMT permit after the lottery drawing
-for a given date.
+Vacancies in this table indicate the availability of a southbound John Muir Trail permit, available for immediate reservation by filling out the online [permit request form](https://yosemite.org/yosemite-wilderness-permit-request-form/).
+This strategy enables securing a soutbound JMT permit after the lottery drawing for a given date.
 
-**Learn more about using hackjohn** and its history of success in the blog post
-titled [**Introducing the hackjohn bot for southbound John Muir Trail permits**](https://hive.blog/@dhimmel/introducing-the-hackjohn-bot-for-southbound-john-muir-trail-permits)
-and _The Mercury News_ article titled [**Here’s how to get a coveted reservation to hike the John Muir Trail**](https://www.mercurynews.com/2019/04/22/heres-how-to-get-a-reservation-to-hike-the-john-muir-trail/ "Written by Lisa M. Krieger on April 22, 2019").
+**Learn more about using hackjohn** and its history of success in the blog post titled [**Introducing the hackjohn bot for southbound John Muir Trail permits**](https://hive.blog/@dhimmel/introducing-the-hackjohn-bot-for-southbound-john-muir-trail-permits) and _The Mercury News_ article titled [**Here’s how to get a coveted reservation to hike the John Muir Trail**](https://www.mercurynews.com/2019/04/22/heres-how-to-get-a-reservation-to-hike-the-john-muir-trail/ "Written by Lisa M. Krieger on April 22, 2019").
 
 ## Usage
 
 Modify [`hackjohn.py`](hackjohn.py) with the parameters of your permit search.
-Add your 2Captcha API key (see the Captcha solving service section) and then 
-set your tokens for Telegram, IFTTT, and/or Twilio to receive notifications 
-(see the Notifications section). Then simply run the hackjohn Python script in 
-the `hackjohn` appropriate environment (see Environment section) with:
+Add your 2Captcha API key (see the Captcha solving service section) and then set your tokens for Telegram, IFTTT, and/or Twilio to receive notifications (see the Notifications section).
+Then simply run the hackjohn Python script in the `hackjohn` appropriate environment (see Environment section) with:
 
 ```shell
 python hackjohn.py
 ```
 
-The script will print some progress messages and at the end it will print a
-message containing available permit details. The same message will be sent via
-whichever notification services you set up. An example of the report is:
+The script will print some progress messages and at the end it will print a message containing available permit details.
+The same message will be sent via whichever notification services you set up.
+An example of the report is:
 
 ```
 2021-08-20:
@@ -43,88 +36,57 @@ Permit request form: https://yosemite.org/yosemite-wilderness-permit-request-for
 Permit office phone: 209-372-0826
 ```
 
-By default, hackjohn writes the output to the file `hackjohn-output.txt` (as 
-specified by the `OUTPUT_PATH` variable in `config.py`). To avoid repeated 
-notification, hackjohn skips sending notifications if its output matches the 
-pre-existing output.
+By default, hackjohn writes the output to the file `hackjohn-output.txt` (as specified by the `OUTPUT_PATH` variable in `config.py`).
+To avoid repeated notification, hackjohn skips sending notifications if its output matches the pre-existing output.
 
 ## Captcha solving service
 
-As of June 22, 2020, the trailhead report switched to a new website that moved
-the permit report behind a Recaptcha (the "I am not a robot" thing). This made 
-it more difficult for bots to access the report. 
+As of June 22, 2020, the trailhead report switched to a new website that moved the permit report behind a Recaptcha (the "I am not a robot" thing).
+This made it more difficult for bots to access the report. 
 
-hackjohn uses [2Captcha](https://2captcha.com) to solve the Recaptcha and get 
-to the permit report. You will need to create a 2Captcha account and
-upload some funds, then copy your 2Captcha API key into the `CAPTCHA_API_KEY`
-variable in [`hackjohn.py`](hackjohn.py). 
+hackjohn uses [2Captcha](https://2captcha.com) to solve the Recaptcha and get to the permit report.
+You will need to create a 2Captcha account and upload some funds, then copy your 2Captcha API key into the `CAPTCHA_API_KEY` variable in [`hackjohn.py`](hackjohn.py). 
 
-This costs money, but it is very cheap (a few dollars will get you 1000 
-Recaptchas). hackjohn reuses the same Recaptcha authorization as long as it is
-still valid, so it only calls the 2Captcha service when necessary (currently
-the authentication lasts about a day, but that is subject to change).
-Realistically, it will cost you at most a couple dollars to run hackjohn 
-multiple times per day for an entire year.
+This costs money, but it is very cheap (a few dollars will get you 1000 Recaptchas).
+hackjohn reuses the same Recaptcha authorization as long as it is still valid, so it only calls the 2Captcha service when necessary (currently the authentication lasts about a day, but that is subject to change).
+Realistically, it will cost you at most a couple dollars to run hackjohn multiple times per day for an entire year.
 
-**Note:** There are many alternatives to 2Captcha and they all work pretty much
-the same way. I didn't have any particular reason for choosing 2Captcha. Feel 
-free to use a different Captcha solving service, but you will need to make
-modifications to the code.
+**Note:** There are many alternatives to 2Captcha and they all work pretty much the same way.
+I didn't have any particular reason for choosing 2Captcha.
+Feel free to use a different Captcha solving service, but you will need to make modifications to the code.
 
 ## Notifications
 
 hackjohn supports the following services to provide notifications:
 
-* **The Telegram messaging app.** Refer to the 
-[webhook2telegram repo](https://github.com/muety/webhook2telegram) for more
-details.
-  1. Download the Telegram app at https://telegram.org. Mobile and desktop apps
-  are available.
+* **The Telegram messaging app.** Refer to the [webhook2telegram repo](https://github.com/muety/webhook2telegram) for more details.
+  1. Download the Telegram app at https://telegram.org. Mobile and desktop apps are available.
   2. Message "\start" to @MiddleManBot. It will send back a token.
-  3. In [`hackjohn.py`](hackjohn.py), set `ENABLE_TELEGRAM` to True and set 
-  `TELEGRAM_TOKEN` to the token you received in the previous step.
+  3. In [`hackjohn.py`](hackjohn.py), set `ENABLE_TELEGRAM` to True and set `TELEGRAM_TOKEN` to the token you received in the previous step.
 
 * **If This Then That (IFTTT).** (Thanks Markus Neuhoff for 
 [contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!)
-  1. Create an applet at https://ifttt.com/create. (You will also need to create
-  an IFTTT account.)
-  2. In the "If This" section of your applet, click "Webhooks" and then 
-  "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to 
-  the `IFTTT_EVENT_NAME` variable in [`hackjohn.py`](hackjohn.py).
-  3. In the "Then That" section of your applet, select the type of notification
-  you would like to receive. For example, "Notifications -> Send a rich 
-  notification from the IFTTT app" or "Email -> Send me an email".
-  4. Go to https://ifttt.com/maker_webhooks, click on documentation, and copy 
-  your key at the top of the screen into the `IFTTT_KEY` variable and set
-  `ENABLE_IFTTT` to True in [`hackjohn.py`](hackjohn.py).
+  1. Create an applet at https://ifttt.com/create. (You will also need to create an IFTTT account.)
+  2. In the "If This" section of your applet, click "Webhooks" and then "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to the `IFTTT_EVENT_NAME` variable in [`hackjohn.py`](hackjohn.py).
+  3. In the "Then That" section of your applet, select the type of notification you would like to receive. For example, "Notifications -> Send a rich notification from the IFTTT app" or "Email -> Send me an email".
+  4. Go to https://ifttt.com/maker_webhooks, click on documentation, and copy your key at the top of the screen into the `IFTTT_KEY` variable and set `ENABLE_IFTTT` to True in [`hackjohn.py`](hackjohn.py).
 
 * **SMS text messages with Twilio.**
   1. Create an account at https://www.twilio.com.
-  2. In the "Project Info" section of your Twilio dashboard, copy your Account
-  SID and Auth Token values into the `TWILIO_ACCOUNT_SID` and 
-  `TWILIO_AUTH_TOKEN` variables in [`hackjohn.py`](hackjohn.py), respectively.
-  3. Click "Get a trial phone number" in your Twilio dashboard. Twilio will
-  generate a phone number for your account. Copy this phone number into the 
-  `TWILIO_PHONE_NUMBER` variable in [`hackjohn.py`](hackjohn.py).
-  4. Set the `TWILIO_TO_PHONE` variable to the phone number you want to send
-   notifications to (i.e., your phone number) and set`ENABLE_TWILIO` to True in
-   [`hackjohn.py`](hackjohn.py).
-  5. **Note:** It costs a small amount of money to operate your Twilio account
-  (currently $1 per month to maintain your phone number plus $0.0075 per 
-  message sent). It is often possible to find promos that will add money to 
-  your account. For example, there is currently a promo code for $50 in free
-  credits in the "Basic Training" section in [Twilio Quest](https://www.twilio.com/quest)
-  (working as of March 2021).
+  2. In the "Project Info" section of your Twilio dashboard, copy your Account SID and Auth Token values into the `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` variables in [`hackjohn.py`](hackjohn.py), respectively.
+  3. Click "Get a trial phone number" in your Twilio dashboard. Twilio will generate a phone number for your account. Copy this phone number into the `TWILIO_PHONE_NUMBER` variable in [`hackjohn.py`](hackjohn.py).
+  4. Set the `TWILIO_TO_PHONE` variable to the phone number you want to send notifications to (i.e., your phone number) and set`ENABLE_TWILIO` to True in [`hackjohn.py`](hackjohn.py).
+  5. **Note:** It costs a small amount of money to operate your Twilio account (currently $1 per month to maintain your phone number plus $0.0075 per message sent).
+  It is often possible to find promos that will add money to your account.
+  For example, there is currently a promo code for $50 in free credits in the "Basic Training" section in [Twilio Quest](https://www.twilio.com/quest) (working as of March 2021).
 
-hackjohn can be run without enabling notifications, which is useful for 
-prototyping and development, but less useful for automated monitoring.
+hackjohn can be run without enabling notifications, which is useful for prototyping and development, but less useful for automated monitoring.
 
 ## Environment
 
-The recommended installation method is to create a virtual environment for just
-hackjohn. This ensures installation does not modify dependencies for other 
-projects. To install a [virtual environment](https://docs.python.org/3/tutorial/venv.html), 
-run the following:
+The recommended installation method is to create a virtual environment for just hackjohn.
+This ensures installation does not modify dependencies for other projects.
+To install a [virtual environment](https://docs.python.org/3/tutorial/venv.html), run the following:
 
 ```shell
 # Create a virtual environment in the env directory

--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ Feel free to use a different Captcha solving service, but you will need to make 
 
 hackjohn supports the following services to provide notifications:
 
-* **The Telegram messaging app.** Refer to the [webhook2telegram repo](https://github.com/muety/webhook2telegram) for more details.
+* **The Telegram messaging app.**
+Refer to the [webhook2telegram repo](https://github.com/muety/webhook2telegram) for more details.
   1. Download the Telegram app at https://telegram.org. Mobile and desktop apps are available.
   2. Message "\start" to @MiddleManBot. It will send back a token.
   3. In [`hackjohn.py`](hackjohn.py), set `ENABLE_TELEGRAM` to True and set `TELEGRAM_TOKEN` to the token you received in the previous step.
 
-* **If This Then That (IFTTT).** (Thanks Markus Neuhoff for 
-[contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!)
+* **If This Then That (IFTTT).**
+(Thanks Markus Neuhoff for [contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!)
   1. Create an applet at https://ifttt.com/create. (You will also need to create an IFTTT account.)
   2. In the "If This" section of your applet, click "Webhooks" and then "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to the `IFTTT_EVENT_NAME` variable in [`hackjohn.py`](hackjohn.py).
   3. In the "Then That" section of your applet, select the type of notification you would like to receive. For example, "Notifications -> Send a rich notification from the IFTTT app" or "Email -> Send me an email".

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ This strategy enables securing a soutbound JMT permit after the lottery drawing 
 
 ## Usage
 
-Modify [`hackjohn.py`](hackjohn.py) with the parameters of your permit search.
-Add your 2Captcha API key (see the Captcha solving service section) and then set your tokens for Telegram, IFTTT, and/or Twilio to receive notifications (see the Notifications section).
-Then simply run the hackjohn Python script in the `hackjohn` appropriate environment (see Environment section) with:
+Follow these steps to run hackjohn:
+
+1. Clone this repository.
+2. Modify [`config.py`](config.py) with with the parameters of your permit search.
+This includes your 2Captcha API key (see the Captcha solving service section) and your tokens for Telegram, IFTTT, and/or Twilio (see the Notifications section).
+3. Then simply run the hackjohn Python script in the `hackjohn` appropriate environment (see Environment section) with:
 
 ```shell
 python hackjohn.py
@@ -45,7 +48,7 @@ As of June 22, 2020, the trailhead report switched to a new website that moved t
 This made it more difficult for bots to access the report. 
 
 hackjohn uses [2Captcha](https://2captcha.com) to solve the Recaptcha and get to the permit report.
-You will need to create a 2Captcha account and upload some funds, then copy your 2Captcha API key into the `CAPTCHA_API_KEY` variable in [`hackjohn.py`](hackjohn.py). 
+You will need to create a 2Captcha account and upload some funds, then copy your 2Captcha API key into the `CAPTCHA_API_KEY` variable in [`config.py`](config.py).
 
 This costs money, but it is very cheap (a few dollars will get you 1000 Recaptchas).
 hackjohn reuses the same Recaptcha authorization as long as it is still valid, so it only calls the 2Captcha service when necessary (currently the authentication lasts about a day, but that is subject to change).
@@ -63,20 +66,20 @@ hackjohn supports the following services to provide notifications:
 Refer to the [webhook2telegram repo](https://github.com/muety/webhook2telegram) for more details.
   1. Download the Telegram app at https://telegram.org. Mobile and desktop apps are available.
   2. Message "\start" to @MiddleManBot. It will send back a token.
-  3. In [`hackjohn.py`](hackjohn.py), set `ENABLE_TELEGRAM` to True and set `TELEGRAM_TOKEN` to the token you received in the previous step.
+  3. In [`config.py`](config.py), set `ENABLE_TELEGRAM` to True and set `TELEGRAM_TOKEN` to the token you received in the previous step.
 
 * **If This Then That (IFTTT).**
 (Thanks Markus Neuhoff for [contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!)
   1. Create an applet at https://ifttt.com/create. (You will also need to create an IFTTT account.)
-  2. In the "If This" section of your applet, click "Webhooks" and then "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to the `IFTTT_EVENT_NAME` variable in [`hackjohn.py`](hackjohn.py).
+  2. In the "If This" section of your applet, click "Webhooks" and then "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to the `IFTTT_EVENT_NAME` variable in [`config.py`](config.py).
   3. In the "Then That" section of your applet, select the type of notification you would like to receive. For example, "Notifications -> Send a rich notification from the IFTTT app" or "Email -> Send me an email".
-  4. Go to https://ifttt.com/maker_webhooks, click on documentation, and copy your key at the top of the screen into the `IFTTT_KEY` variable and set `ENABLE_IFTTT` to True in [`hackjohn.py`](hackjohn.py).
+  4. Go to https://ifttt.com/maker_webhooks, click on documentation, and copy your key at the top of the screen into the `IFTTT_KEY` variable and set `ENABLE_IFTTT` to True in [`config.py`](config.py).
 
 * **SMS text messages with Twilio.**
   1. Create an account at https://www.twilio.com.
-  2. In the "Project Info" section of your Twilio dashboard, copy your Account SID and Auth Token values into the `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` variables in [`hackjohn.py`](hackjohn.py), respectively.
-  3. Click "Get a trial phone number" in your Twilio dashboard. Twilio will generate a phone number for your account. Copy this phone number into the `TWILIO_PHONE_NUMBER` variable in [`hackjohn.py`](hackjohn.py).
-  4. Set the `TWILIO_TO_PHONE` variable to the phone number you want to send notifications to (i.e., your phone number) and set`ENABLE_TWILIO` to True in [`hackjohn.py`](hackjohn.py).
+  2. In the "Project Info" section of your Twilio dashboard, copy your Account SID and Auth Token values into the `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` variables in [`config.py`](config.py), respectively.
+  3. Click "Get a trial phone number" in your Twilio dashboard. Twilio will generate a phone number for your account. Copy this phone number into the `TWILIO_PHONE_NUMBER` variable in [`config.py`](config.py).
+  4. Set the `TWILIO_TO_PHONE` variable to the phone number you want to send notifications to (i.e., your phone number) and set`ENABLE_TWILIO` to True in [`config.py`](config.py).
   5. **Note:** It costs a small amount of money to operate your Twilio account (currently $1 per month to maintain your phone number plus $0.0075 per message sent).
   It is often possible to find promos that will add money to your account.
   For example, there is currently a promo code for $50 in free credits in the "Basic Training" section in [Twilio Quest](https://www.twilio.com/quest) (working as of March 2021).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ and _The Mercury News_ article titled [**Here’s how to get a coveted reservati
 ## Usage
 
 Modify [`hackjohn.py`](hackjohn.py) with the parameters of your permit search.
-Set your tokens for Middleman, IFTTT, and/or Twilio to receive notifications
-(see the Notifications section below for more details). Then simply run the 
-hackjohn Python script in the `hackjohn` appropriate environment (described 
-below) with:
+Add your 2Captcha API key (see the Captcha solving service section) and then 
+set your tokens for Telegram, IFTTT, and/or Twilio to receive notifications 
+(see the Notifications section). Then simply run the hackjohn Python script in 
+the `hackjohn` appropriate environment (see Environment section) with:
 
 ```shell
 python hackjohn.py

--- a/README.md
+++ b/README.md
@@ -1,76 +1,130 @@
-## Eulogy
-
-As of June 22, 2020, the trailhead report switched to a [new website](https://yosemite.org/planning-your-wilderness-permit/) that forbids automated access.
-Therefore, it is no longer possible to get notifications of trailhead availability.
-More information is available at <https://github.com/dhimmel/hackjohn/issues/9> (solutions welcome).
-
-For over 2 years, Hackjohn helped users save time, and avoid having to repeatedly check a website.
-Thanks everyone who contributed.
-I hope you found this tool helpful.
-And I'm happy Hackjohn introduced several users to coding and Python.
-
 # Bot to monitor for southbound permit spaces on the John Muir Trail
 
 [![Hackjohn CI](https://github.com/dhimmel/hackjohn/workflows/Hackjohn%20CI/badge.svg?branch=master)](https://github.com/dhimmel/hackjohn/actions)
 
-This repository contains a Python script for monitoring Yosemite's [Donohue Exit Quota and Trailhead Space Available](https://www.nps.gov/yose/planyourvisit/fulltrailheads.htm) online table.
-Vacancies in this table indicate the availability of a southbound John Muir Trail permit,
-available for immediate reservation by calling the Yosemite Wilderness Permit Reservations at [1-209-372-0740](tel:1-209-372-0740).
-This strategy enables securing a soutbound JMT permit after the lottery drawing for a given date.
+This repository contains a Python script for monitoring Yosemite's [permit availability report](https://yosemite.org/planning-your-wilderness-permit/).
+Vacancies in this table indicate the availability of a southbound John Muir 
+Trail permit, available for immediate reservation by filling out the online 
+[permit request form](https://yosemite.org/yosemite-wilderness-permit-request-form/).
+This strategy enables securing a soutbound JMT permit after the lottery drawing
+for a given date.
 
-**Learn more about using hackjohn** and its history of success in the blog post titled [**Introducing the hackjohn bot for southbound John Muir Trail permits**](https://hive.blog/@dhimmel/introducing-the-hackjohn-bot-for-southbound-john-muir-trail-permits) and _The Mercury News_ article titled [**Here’s how to get a coveted reservation to hike the John Muir Trail**](https://www.mercurynews.com/2019/04/22/heres-how-to-get-a-reservation-to-hike-the-john-muir-trail/ "Written by Lisa M. Krieger on April 22, 2019").
+**Learn more about using hackjohn** and its history of success in the blog post
+titled [**Introducing the hackjohn bot for southbound John Muir Trail permits**](https://hive.blog/@dhimmel/introducing-the-hackjohn-bot-for-southbound-john-muir-trail-permits)
+and _The Mercury News_ article titled [**Here’s how to get a coveted reservation to hike the John Muir Trail**](https://www.mercurynews.com/2019/04/22/heres-how-to-get-a-reservation-to-hike-the-john-muir-trail/ "Written by Lisa M. Krieger on April 22, 2019").
 
 ## Usage
 
 Modify [`hackjohn.py`](hackjohn.py) with the parameters of your permit search.
-To receive [Telegram](https://telegram.org/) notfications, set your `token` for the [MiddleManBot](https://github.com/n1try/telegram-middleman-bot).
-Then simply run the hackjohn Python script in the `hackjohn` appropriate environment (described below) with:
+Set your tokens for Middleman, IFTTT, and/or Twilio to receive notifications
+(see the Notifications section below for more details). Then simply run the 
+hackjohn Python script in the `hackjohn` appropriate environment (described 
+below) with:
 
 ```shell
 python hackjohn.py
 ```
 
-The script with print the table of available spaces via stdout.
-An example of the output is:
+The script will print some progress messages and at the end it will print a
+message containing available permit details. The same message will be sent via
+whichever notification services you set up. An example of the report is:
 
 ```
-Spaces available as of 2020-05-23:
+2021-08-20:
+5 permits for Happy Isles->Little Yosemite Valley
+2 permits for Lyell Canyon
 
-      Date      Trailhead  Spaces
-2020-09-27   Lyell Canyon       5
-2020-09-28   Lyell Canyon       8
-2020-09-29  Sunrise Lakes       5
-2020-09-29   Lyell Canyon      15
-2020-09-30   Lyell Canyon       7
+2021-09-03:
+1 permit for Happy Isles->Little Yosemite Valley
 
-According to https://www.nps.gov/yose/planyourvisit/fulltrailheads.htm
-Yosemite Reservations: 209-372-0740 (Monday–Friday 9:00am–4:30pm)
+Report last updated 2021-03-20 10:34:32 AM PDT.
 
-output has changed: False
+Permit request form: https://yosemite.org/yosemite-wilderness-permit-request-form/
+Permit office phone: 209-372-0826
 ```
 
-By default, Hackjohn writes the output to the file `hackjohn-output.txt` (as specified by `output_path`).
-To avoid repeated notification, Hackjohn skips Telegram notification if its output matches the pre-existing output.
+By default, hackjohn writes the output to the file `hackjohn-output.txt` (as 
+specified by the `OUTPUT_PATH` variable in `config.py`). To avoid repeated 
+notification, hackjohn skips sending notifications if its output matches the 
+pre-existing output.
+
+## Captcha solving service
+
+As of June 22, 2020, the trailhead report switched to a new website that moved
+the permit report behind a Recaptcha (the "I am not a robot" thing). This made 
+it more difficult for bots to access the report. 
+
+hackjohn uses [2Captcha](https://2captcha.com) to solve the Recaptcha and get 
+to the permit report. You will need to create a 2Captcha account and
+upload some funds, then copy your 2Captcha API key into the `CAPTCHA_API_KEY`
+variable in [`hackjohn.py`](hackjohn.py). 
+
+This costs money, but it is very cheap (a few dollars will get you 1000 
+Recaptchas). hackjohn reuses the same Recaptcha authorization as long as it is
+still valid, so it only calls the 2Captcha service when necessary (currently
+the authentication lasts about a day, but that is subject to change).
+Realistically, it will cost you at most a couple dollars to run hackjohn 
+multiple times per day for an entire year.
+
+**Note:** There are many alternatives to 2Captcha and they all work pretty much
+the same way. I didn't have any particular reason for choosing 2Captcha. Feel 
+free to use a different Captcha solving service, but you will need to make
+modifications to the code.
 
 ## Notifications
 
-Hackjohns supports the following services to provide notifications:
+hackjohn supports the following services to provide notifications:
 
-1. **the [Telegram](https://telegram.org/) messaging app.**
-   Configure `enable_middleman` and `token` in [`hackjohn.py`](hackjohn.py) to use this feature.
+* **The Telegram messaging app.** Refer to the 
+[webhook2telegram repo](https://github.com/muety/webhook2telegram) for more
+details.
+  1. Download the Telegram app at https://telegram.org. Mobile and desktop apps
+  are available.
+  2. Message "\start" to @MiddleManBot. It will send back a token.
+  3. In [`hackjohn.py`](hackjohn.py), set `ENABLE_TELEGRAM` to True and set 
+  `TELEGRAM_TOKEN` to the token you received in the previous step.
 
-2. **If This Than That ([IFTTT](https://ifttt.com/)).**
-   To enable IFTTT follow the instructions in `hackjohn.py` to create an IFTTT applet.
-   Configure `enable_ifttt` and `ifttt_key` in `hackjohn.py`.
-   Thanks Markus Neuhoff for [contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!
+* **If This Then That (IFTTT).** (Thanks Markus Neuhoff for 
+[contributing](https://github.com/dhimmel/hackjohn/pull/4) this feature!)
+  1. Create an applet at https://ifttt.com/create. (You will also need to create
+  an IFTTT account.)
+  2. In the "If This" section of your applet, click "Webhooks" and then 
+  "Receive a web request". Give it a name (e.g., "hackjohn"). Add this name to 
+  the `IFTTT_EVENT_NAME` variable in [`hackjohn.py`](hackjohn.py).
+  3. In the "Then That" section of your applet, select the type of notification
+  you would like to receive. For example, "Notifications -> Send a rich 
+  notification from the IFTTT app" or "Email -> Send me an email".
+  4. Go to https://ifttt.com/maker_webhooks, click on documentation, and copy 
+  your key at the top of the screen into the `IFTTT_KEY` variable and set
+  `ENABLE_IFTTT` to True in [`hackjohn.py`](hackjohn.py).
 
-Hackjohn can be run without enabling notifications, which is usefull for prototyping and development, but less useful for automated monitoring.
+* **SMS text messages with Twilio.**
+  1. Create an account at https://www.twilio.com.
+  2. In the "Project Info" section of your Twilio dashboard, copy your Account
+  SID and Auth Token values into the `TWILIO_ACCOUNT_SID` and 
+  `TWILIO_AUTH_TOKEN` variables in [`hackjohn.py`](hackjohn.py), respectively.
+  3. Click "Get a trial phone number" in your Twilio dashboard. Twilio will
+  generate a phone number for your account. Copy this phone number into the 
+  `TWILIO_PHONE_NUMBER` variable in [`hackjohn.py`](hackjohn.py).
+  4. Set the `TWILIO_TO_PHONE` variable to the phone number you want to send
+   notifications to (i.e., your phone number) and set`ENABLE_TWILIO` to True in
+   [`hackjohn.py`](hackjohn.py).
+  5. **Note:** It costs a small amount of money to operate your Twilio account
+  (currently $1 per month to maintain your phone number plus $0.0075 per 
+  message sent). It is often possible to find promos that will add money to 
+  your account. For example, there is currently a promo code for $50 in free
+  credits in the "Basic Training" section in [Twilio Quest](https://www.twilio.com/quest)
+  (working as of March 2021).
+
+hackjohn can be run without enabling notifications, which is useful for 
+prototyping and development, but less useful for automated monitoring.
 
 ## Environment
 
-The recommend installation method is to create a virtual environment for just Hackjohn.
-This ensures installation does not modify dependencies for other projects.
-To install a [virtual environment](https://docs.python.org/3/tutorial/venv.html), run the following:
+The recommended installation method is to create a virtual environment for just
+hackjohn. This ensures installation does not modify dependencies for other 
+projects. To install a [virtual environment](https://docs.python.org/3/tutorial/venv.html), 
+run the following:
 
 ```shell
 # Create a virtual environment in the env directory
@@ -82,7 +136,7 @@ source env/bin/activate
 # Install the required dependencies into the virtual env
 pip install --requirement requirements.txt
 
-# Now you can run Hackjohn
+# Now you can run hackjohn
 python hackjohn.py
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,9 +1,60 @@
 """
-MODIFY THIS FILE AT YOUR OWN RISK.
+Set the parameters at the top of this file to control which dates and
+trailheads you are notified for and which types of notifications you receive.
 
-Configuration variables for the hackjohn.py script. You should only make changes
-to these values if you have a good reason and know what you are doing.
+This should be the only file you need to modify. After you fill in the
+parameters in this file, you can run hackjohn.py.
 """
+
+# replace with your 2Captcha API key (required)
+CAPTCHA_API_KEY = "your-2Captcha-api-key"
+
+# customize the dates and trailheads you want to be notified for
+MIN_SPACES = 1  # minimum number of available spaces
+START_DATE = "2021-06-15"  # earliest date you would like to start your hike
+END_DATE = "2021-09-30"    # latest date you would like to start your hike
+NOTIFY_IF_NO_PERMITS = True  # send daily notification even if no permits are found?
+OUTPUT_TIME_ZONE = "US/Pacific"  # what time zone to show in notifications (must be in pytz.all_timezones)
+
+# Comment out trailheads you'd like to start from (don't change the trailhead names)
+EXCLUDE_TRAILHEADS = [
+    # "Happy Isles->Little Yosemite Valley",
+    # "Happy Isles->Sunrise/Merced Lake (pass through)",
+    # "Glacier Point->Little Yosemite Valley",
+    # "Sunrise Lakes",
+    # "Lyell Canyon",
+]
+
+## Telegram notification setup (optional)
+ENABLE_TELEGRAM = False
+TELEGRAM_TOKEN = "replace-with-personal-telegram-token"
+TELEGRAM_FROM_NAME = "hackjohn"
+
+## IFTTT notification setup (optional)
+ENABLE_IFTTT = False
+IFTTT_KEY = "replace-with-personal-IFTTT-key"
+IFTTT_EVENT_NAME = "hackjohn"  # must match the name of the event you created
+
+## Twilio SMS notification setup (optional)
+ENABLE_TWILIO = False
+TWILIO_ACCOUNT_SID = "your-twilio-account-sid"
+TWILIO_AUTH_TOKEN = "your-twilio-auth-token"
+TWILIO_PHONE_NUMBER = "your-twilio-account-phone-number"   # +1xxxxxxxxxx format
+TWILIO_TO_PHONE = "phone-number-to-receive-notifications"  # +1xxxxxxxxxx format
+
+"""
+END OF REQUIRED PARAMETERS
+
+--------------------------------------------------------------------------------
+
+MODIFY THE CODE BELOW AT YOUR OWN RISK.
+
+The values below are used in hackjohn.py, but they are not user specific and
+you do not need to change them. You should only make changes to these values if
+you have a good reason (i.e., the website has changed and hackjohn is broken)
+and know what you are doing.
+"""
+
 import pathlib
 
 # Write output to this file. If the generated output is identical to the

--- a/config.py
+++ b/config.py
@@ -1,0 +1,50 @@
+"""
+MODIFY THIS FILE AT YOUR OWN RISK.
+
+Configuration variables for the hackjohn.py script. You should only make changes
+to these values if you have a good reason and know what you are doing.
+"""
+import pathlib
+
+# Write output to this file. If the generated output is identical to the
+# existing output at this path, suppress notification. To disable writing any
+# files, set to None.
+OUTPUT_PATH = pathlib.Path("__file__").parent.joinpath("hackjohn-output.txt")
+
+# If the Report Date is before this day, suppress notification. You probably
+# do not need to change this setting unless you have disabled OUTPUT_PATH
+MIN_REPORT_DATE = "2019-01-01"
+
+# information required for solving the recaptcha
+WEBSITE_URL = "https://yosemite.org/planning-your-wilderness-permit/"
+REFERRER_URL = "https://yosemite.org/planning-your-wilderness-permit/"
+RECAPTCHA_SITE_KEY = "6LeWjvIUAAAAAC54MkeI2YX6DGTk86-DeDHHB9-J"
+RECAPTCHA_REQUEST_URL = "https://yosemite.org/wp-content/plugins/wildtrails/captcha.php"
+
+# how many times to retry recaptcha if there is an exception, and how long between tries
+MAX_RETRY_ATTEMPTS = 5
+RECAPTCHA_RETRY_INTERVAL = 15  # in seconds
+
+# save cookies to this file so they can be reused if still valid
+COOKIE_FILE = pathlib.Path("__file__").parent.joinpath(".cookies.pickle")
+
+# API endpoints
+JMT_REPORT_ENDPOINT = "https://yosemite.org/wp-content/plugins/wildtrails/query.php?resource=report&region=jm"
+TRAILHEAD_ENDPOINT = "https://yosemite.org/wp-content/plugins/wildtrails/query.php?resource=trailheads"
+
+# phone number for permit office (previous number was 209-372-0740)
+PERMIT_OFFICE_PHONE = "209-372-0826"
+PERMIT_REQUEST_FORM_URL = "https://yosemite.org/yosemite-wilderness-permit-request-form/"
+
+# URLs for Telegram and IFTTT notifications
+TELEGRAM_URL = "https://apps.muetsch.io/webhook2telegram/api/messages"
+IFTTT_HOSTNAME = "https://maker.ifttt.com"
+
+# These values are set are set using javascript on the trailhead report website
+# (specifically in index.php). I don't know how to dynamically pull the values
+# so I'm hard-coding the current values here. They probably won't change anyway.
+# Maybe we could dynamically pull them in a future enhancement.
+MAX_RESERVE_DAYS = 168
+MIN_RESERVE_DAYS = 2
+OPEN_DATE = "06-15"   # first calendar date JMT permits are available (MM-DD)
+CLOSE_DATE = "09-30"  # last calendar date JMT permits are available (MM-DD)

--- a/hackjohn.py
+++ b/hackjohn.py
@@ -29,6 +29,7 @@ from tenacity import (
     wait_fixed,
     retry_if_exception_type
 )
+from twilio.rest import Client
 
 # some variables are set in config.py -- not intended to be modified
 import config
@@ -471,11 +472,6 @@ def send_IFTTT_notification(text: str):
     url = f"{config.IFTTT_HOSTNAME}/trigger/{IFTTT_EVENT_NAME}/with/key/{IFTTT_KEY}"
     r = requests.post(url, data=report)
     r.raise_for_status()
-
-
-# only need the twilio package if we're sending SMS
-if ENABLE_TWILIO:
-    from twilio.rest import Client
 
 
 def send_twilio_notification(

--- a/hackjohn.py
+++ b/hackjohn.py
@@ -9,175 +9,522 @@ This is for people hiking the John Muir Trail starting in Yosemite.
 According to the reservations office,
 the table is usually updated around 11 AM pacific time
 and spaces are usually snatched within ten minutes.
-Call the reservation number if there's availability at 209-372-0740.
+Fill out the online permit request form if there are available permits:
+https://yosemite.org/yosemite-wilderness-permit-request-form/
 """
 
 import pathlib
-import re
-
 import requests
-import pandas
-from pkg_resources import parse_version
+import json
+from datetime import datetime, timedelta
+import pytz
+from twocaptcha import TwoCaptcha
+from typing import Tuple, Union, List
+import warnings
+import pickle
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_fixed,
+    retry_if_exception_type
+)
 
-# Minimum number of available spaces
-spaces = 2
+# some variables are set in config.py -- not intended to be modified
+import config
 
-# Comment out trailheads you'd like to start from
-exclude = [
-    # "HI → LYV",
-    # "HI → Sunrise/Merced Lakes (Pass through)",
-    # "Glacier Point → LYV",
+
+######################
+# Set these parameters
+######################
+CAPTCHA_API_KEY = "your-api-key"  # replace with your 2Captcha API key
+MIN_SPACES = 1  # minimum number of available spaces
+START_DATE = "2021-06-15"  # earliest date you would like to start your hike
+END_DATE = "2021-09-30"    # latest date you would like to start your hike
+NOTIFY_IF_NO_PERMITS = True  # send daily notification even if no permits are found?
+OUTPUT_TIME_ZONE = "US/Pacific"  # what time zone to show in notifications (must be in pytz.all_timezones)
+
+# Comment out trailheads you'd like to start from (don't change the trailhead names)
+EXCLUDE_TRAILHEADS = [
+    # "Happy Isles->Little Yosemite Valley",
+    # "Happy Isles->Sunrise/Merced Lake (pass through)",
+    # "Glacier Point->Little Yosemite Valley",
     # "Sunrise Lakes",
     # "Lyell Canyon",
 ]
 
-# Dates you'd like to start on (inclusive of end date)
-dates = pandas.date_range(start="2020-08-01", end="2020-09-30", freq="D")
-dates
+## Telegram notification setup (optional)
+ENABLE_TELEGRAM = False
+TELEGRAM_TOKEN = "replace-with-personal-telegram-token"
+TELEGRAM_FROM_NAME = "hackjohn"
 
-# Write output to this file. If the generated output is identical to
-# the existing output at this path, suppress notification. To disable
-# writing any files, set output_path=None as shown below.
-output_path = pathlib.Path("__file__").parent.joinpath("hackjohn-output.txt")
-# output_path = None  # None disables writing to a file
+## IFTTT notification setup (optional)
+ENABLE_IFTTT = False
+IFTTT_KEY = "replace-with-personal-IFTTT-key"
+IFTTT_EVENT_NAME = "hackjohn"  # must match the name of the event you created
 
-# If the Report Date is before this day, suppress Telegram notification.
-# You probably do not need to change this setting unless you have disabled
-# output_path
-min_report_date = "2019-01-01"
+## Twilio SMS notification setup (optional)
+ENABLE_TWILIO = False
+TWILIO_ACCOUNT_SID = "your-twilio-account-sid"
+TWILIO_AUTH_TOKEN = "your-twilio-auth-token"
+TWILIO_PHONE_NUMBER = "your-twilio-account-phone-number"   # +1xxxxxxxxxx format
+TWILIO_TO_PHONE = "phone-number-to-receive-notifications"  # +1xxxxxxxxxx format
+
+###################
+# end of parameters
+###################
 
 
-def get_trailhead_df():
+def main():
+    # pull permit and trailhead data
+    trailheads = get_trailhead_descriptions()
+    jmt_report, timestamp = get_jmt_report()
+
+    # choose dates, look for available permits for those dates, and create text report
+    permits = find_available_permits(jmt_report, timestamp, trailheads)
+    text = create_text_report(timestamp, permits, trailheads)
+
+    # send notifications as appropriate
+    notify = decide_whether_to_notify(text, permits, timestamp)
+    if notify:
+        if ENABLE_TELEGRAM:
+            send_telegram_notification(text)
+        if ENABLE_IFTTT:
+            send_IFTTT_notification(text)
+        if ENABLE_TWILIO:
+            send_twilio_notification(text)
+
+    print("")
+    print(text)
+
+
+def get_trailhead_descriptions() -> dict:
     """
-    Convert the current "Donohue Exit Quota and Trailhead Space Available" HTML table
-    to a pandas.DataFrame.
-    """
-    pandas_version = parse_version(pandas.__version__)._version.release
-    if pandas_version[:2] == (0, 23):
-        # read_html malfunctions in pandas v0.23
-        # https://github.com/pandas-dev/pandas/issues/22135
-        raise ImportError("pandas v0.23 is not supported due to https://git.io/fp9Zn")
+    Get trailhead information (names, quotas, etc.). Returns a dictionary with
+    an entry for each trailhead.
 
-    url = "https://www.nps.gov/yose/planyourvisit/fulltrailheads.htm"
-    response = requests.get(url)
-    response.raise_for_status()
-
-    (wide_df,) = pandas.read_html(
-        response.text,
-        header=1,
-        attrs={"id": "cs_idLayout2"},
-        flavor="html5lib",
-        # check table at nps trailheads site for irrelevant leading rows
-        # update skiprows value so first row is actual table header
-        skiprows=0,
-        parse_dates=["Date"],
-    )
-    wide_df = wide_df.iloc[:, :6]
-
-    trailhead_df = (
-        wide_df.melt(id_vars="Date", var_name="Trailhead", value_name="Spaces")
-        .dropna()
-        .sort_values(by=["Date"], kind="mergesort")
-    )
-    trailhead_df.Spaces = trailhead_df.Spaces.astype(int)
-    assert len(trailhead_df) > 0
-
-    return response, trailhead_df
-
-
-yose_response, trailhead_df = get_trailhead_df()
-trailhead_df.head(2)
-
-# Extract report date. https://github.com/dhimmel/hackjohn/issues/1
-try:
-    match = re.search(r"Report Date: ([0-9/]+)", yose_response.text)
-    report_date = match.group(1)
-    report_date = pandas.to_datetime(report_date, dayfirst=False)
-except Exception:
-    report_date = yose_response.headers["Date"]
-    report_date = pandas.to_datetime(report_date, utc=True)
-report_date = report_date.date().isoformat()
-
-space_df = trailhead_df.query(
-    "Date in @dates and Spaces >= @spaces and Trailhead not in @exclude"
-)
-space_df
-
-space_str = "NO VACANCY" if space_df.empty else space_df.to_string(index=False)
-text = f"""Spaces available as of {report_date}:
-
-{space_str}
-
-According to {yose_response.url}
-Yosemite Reservations: 209-372-0740 (Monday–Friday 9:00am–4:30pm)
-"""
-print(text)
-# Detect if output_path has changed. If so, rewrite output.
-output_has_changed = True
-if output_path:
-    output_path = pathlib.Path(output_path)
-    if output_path.is_file():
-        previous_text = output_path.read_text()
-        output_has_changed = text != previous_text
-    if output_has_changed:
-        output_path.write_text(text)
-print(f"output has changed: {output_has_changed}")
-
-# determine whether to notify
-notify = not space_df.empty and output_has_changed and min_report_date <= report_date
-
-## Notifications using MiddlemanBot
-# Uses https://github.com/n1try/telegram-middleman-bot
-
-# Set enable_middleman to True to receive telegram notification
-enable_middleman = False
-
-# Get token from messaging /start to @MiddleManBot on Telegram
-# https://telegram.me/MiddleManBot
-token = "replace-with-private-telegram-middlemanbot-token"
-
-hostname = "https://middleman.ferdinand-muetsch.de"
-mmb_url = hostname + "/api/messages"
-payload = {
-    "recipient_token": token,
-    "text": text,
-    "origin": "hackjohn",
-}
-if notify and enable_middleman:
-    mmb_response = requests.post(mmb_url, json=payload)
-    print("middleman status code", mmb_response.status_code)
-    print(mmb_response.text)
-
-## Notifications using IFTTT
-
-# Set enable_ifttt to True and personalize ifttt_key to receive IFTTT notifications
-enable_ifttt = False
-event_name = "hackjohn"
-ifttt_key = "replace-with-ifttt-key"
-
-"""
-## IFTTT Setup Instructions
-
-Create you own IFTTT at https://ifttt.com/create.
-Select webhooks for this and select "Receive a web request".
-Set event name to match `event_name` variable above.
-Create a that to respond to the event.
-For example, select "Send a rich notification from the IFTTT app"
-(IFTTT rich notifications allow click to call options to the reservation line).
-You can add 3 values (specified below).
-For example, use `{{Value1}}` for the message template and `tel: {{Value2}}` as link action.
-Go to https://ifttt.com/maker_webhooks and click on documentation,
-copy & paste your key into the `ifttt_key` variable above.
-"""
-
-ifttt_hostname = "https://maker.ifttt.com"
-ifttt_url = ifttt_hostname + "/trigger/" + event_name + "/with/key/" + ifttt_key
-
-if notify and enable_ifttt:
-    report = {
-        "value1": text,
-        "value2": "209-372-0740",
+    For example, this is the entry for "j01a":
+    {
+        'id': 'j01a',
+        'name': 'Happy Isles to Sunrise/Merced Lake Pass Thru (Donohue Pass only)',
+        'wpsName': 'Happy Isles->Sunrise/Merced Lake (pass through)',
+        'region': 'jm',
+        'latitude': None,
+        'longitude': None,
+        'description': '...',
+        'quota': 6,
+        'capacity': 10,
+        'alert': None,
+        'notes': '...'
     }
-    response = requests.post(ifttt_url, data=report)
-    print("ifttt status code", response.status_code)
-    print(response.text)
+    """
+    print("pulling trailhead information...")
+    raw_data = get_json_from_api(config.TRAILHEAD_ENDPOINT)
+    trailheads = raw_data["response"]["values"]
+    return trailheads
+
+
+def get_jmt_report() -> Tuple[dict, datetime]:
+    """
+    Get the number of reserved permits from each trailhead for each date.
+    Returns a dictionary with keys for dates. Each value is a dictionary with
+    a key for each JMT trailhead. Also returns the timestamp of when the report
+    was last updated (in PST). The raw report is a list of dicts. The list is
+    reformatted into a dictionary to make it easier to work with.
+
+    Here is a sample of the output. There is one entry per date.
+    {
+        '2021-08-01': {
+            'j01a': 6,
+            'j01b': 18,
+            'j03a': 6,
+            'j19': 9,
+            'j24b': 21,
+            'd01': 20,
+            'd02': 15
+        },
+    }
+    """
+    print("pulling JMT permit availability report...")
+    raw_data = get_json_from_api(config.JMT_REPORT_ENDPOINT)
+
+    # get the timestamp
+    report_timestamp = raw_data["response"]["timestamp"]
+    report_timestamp = datetime.strptime(report_timestamp, "%Y-%m-%dT%H:%M:%S")
+    pacific = pytz.timezone("US/Pacific")
+    report_timestamp = pacific.localize(report_timestamp)
+
+    # get the reserved permit counts and reformat
+    report_vals = {}
+    for val_dict in raw_data["response"]["values"]:
+        date = val_dict["date"]
+        report_vals[date] = val_dict.copy()
+        report_vals[date].pop("date")
+
+    return report_vals, report_timestamp
+
+
+@retry(
+    stop=stop_after_attempt(config.MAX_RETRY_ATTEMPTS),
+    retry=retry_if_exception_type(),
+    reraise=True,
+)
+def get_json_from_api(api_url: str) -> dict:
+    """
+    Get the raw data from the specified API. Sends a GET request to the URL
+    provided. Uses saved cookies from the last run if they exist, otherwise
+    authenticates a new session.
+
+    The response for the yosemite.org APIs is a JSON file with keys for
+    "status" and "response". The "status" entry contains a message about
+    whether data was found. The "response" entry contains the data and will be
+    set to None if no data was found.
+
+    If an exception is raised, this function will be retried up to
+    config.MAX_RETRY_ATTEMPTS times.
+
+    :param api_url: URL for the GET request
+    :return: JSON response from the request
+    """
+    cookie_file = pathlib.Path(config.COOKIE_FILE)
+    if cookie_file.is_file():
+        print("using saved cookies...")
+        with open(cookie_file, "rb") as f:
+            cookies = pickle.load(f)
+        s = requests.session()
+        s.cookies.update(cookies)
+
+    else:
+        print("did not find saved cookies -- getting new session...")
+        s = get_authorized_session(api_key=CAPTCHA_API_KEY)
+
+    # pull the data (should be near instantaneous, but sometimes there are
+    # timeout errors which go away upon retrying)
+    query = s.get(api_url, timeout=2)
+    data = json.loads(query.text)
+
+    # data["response"] will be a dict if successful, or None if not authorized
+    if data["response"] is None:
+        print("cookies were not valid -- deleting cookies and retrying with "
+              "new session...")
+        cookie_file.unlink(missing_ok=True)
+        raise ValueError(f"session is not authorized")
+
+    return data
+
+
+@retry(
+    stop=stop_after_attempt(config.MAX_RETRY_ATTEMPTS),
+    wait=wait_fixed(config.RECAPTCHA_RETRY_INTERVAL),
+    retry=retry_if_exception_type(),
+    reraise=True,
+)
+def get_authorized_session(api_key: str) -> requests.Session:
+    """
+    Solve the recaptcha, then authenticate browser by sending the recaptcha
+    response in a POST request. Return the authorized session.
+
+    If an exception is raised, this function will be retried up to
+    config.MAX_RETRY_ATTEMPTS times, waiting config.RECAPTCHA_RETRY_INTERVAL
+    seconds between attempts.
+
+    :param api_key: API key for the captcha solving service
+    """
+    print("solving captcha...")
+    try:
+        recaptcha_response = get_recaptcha_response(api_key)
+        s = requests.session()
+        r = s.post(
+            url=config.RECAPTCHA_REQUEST_URL,
+            data={
+                "g-recaptcha-response": recaptcha_response,
+                "referrer": config.REFERRER_URL,
+            },
+        )
+        r.raise_for_status()  # raise exception if the request didn't work
+
+        # save cookies to a file so we can try reusing later
+        with open(config.COOKIE_FILE, "wb") as f:
+            pickle.dump(s.cookies, f)
+
+        return s
+
+    except Exception as e:
+        print(f"\nerror solving recaptcha -- waiting {config.RECAPTCHA_RETRY_INTERVAL} "
+              f"seconds and trying again...")
+        raise e
+
+
+def get_recaptcha_response(api_key: str) -> str:
+    """
+    Solve the recaptcha  and return the response. This takes a minute or two.
+
+    NOTE: This is configured to use 2Captcha as the captcha solving service. If
+    you want to use a different service you'll have to modify this function.
+    """
+    solver = TwoCaptcha(apiKey=api_key)
+    balance = solver.balance()
+    print(f"2Captcha current balance: ${balance}...")
+    if balance < 0.1:
+        warnings.warn(f"2Captcha balance is running low")
+    r = solver.recaptcha(sitekey=config.RECAPTCHA_SITE_KEY, url=config.WEBSITE_URL)
+    return r["code"]
+
+
+def find_available_permits(jmt_report: dict, timestamp: datetime, trailheads: dict) -> dict:
+    """
+    Search for available permits at JMT trailheads for the appropriate dates.
+    Only include if there are at least MIN_SPACES available. Do not include any
+    trailheads listed in EXCLUDE_TRAILHEADS.
+
+    Logic:
+    - raw report contains number of reserved permits from each trailhead per day
+    - trailhead file contains the entry quota for the trailhead, as well as the
+      exit quota for Donohue Pass (note that Lyell Canyon has different Donohue
+      exit quota)
+    - entry permits available = trailhead quota - trailhead reserved
+    - Donohue exits available = Donohue quota - Donohue reserved
+    --> overall available = min(entry permits available, Donohue exits available)
+
+    Returns a dictionary of available permits. For example:
+    {
+        "2021-08-06: {
+            "j01a": 1,
+            "j24b": 2,
+        },
+        "2021-08-11": {
+            "j01b": 1,
+        }
+    }
+
+    :param jmt_report: dictionary of reserved permits (output of get_jmt_report)
+    :param timestamp: timestamp of the last report update
+    :param trailheads: dictionary of trailhead information (output of
+    get_trailhead_descriptions)
+    """
+    # get appropriate date range based on user input and today's date
+    start_date, end_date = get_start_end_dates(jmt_report, timestamp)
+    print(f"searching for open permits from {start_date} through {end_date}...")
+
+    available_permits = {}
+    for date in date_range(start_date, end_date):
+        permit_data = jmt_report[date]
+        for trailhead_id in permit_data:
+            if trailhead_id in ["d01", "d02"]:
+                continue  # these are exit quotas, not real trailheads
+            if trailheads[trailhead_id]["wpsName"] in EXCLUDE_TRAILHEADS:
+                continue
+
+            quota = trailheads[trailhead_id]["quota"]
+            taken = permit_data[trailhead_id]
+            trailhead_available = quota - taken
+
+            # Lyell Canyon trailhead has a different Donohue Pass exit quota
+            dh = "d02" if trailhead_id == "j24b" else "d01"
+            dh_quota = trailheads[dh]["quota"]
+            dh_taken = permit_data[dh]
+            dh_available = dh_quota - dh_taken
+
+            available = min(trailhead_available, dh_available)
+            available = max(available, 0)
+
+            if available >= max(MIN_SPACES, 1):
+                if date not in available_permits:
+                    available_permits[date] = {}
+                available_permits[date][trailhead_id] = available
+
+    return available_permits
+
+
+def get_start_end_dates(jmt_report: dict, timestamp: datetime) -> Tuple[str, str]:
+    """
+    Choose the date range to look for permits.
+
+    Start date must be greater than or equal to:
+    - START_DATE defined at top of script
+    - first date in the JMT report
+    - last report date + MIN_RESERVE_DAYS (currently 2)
+    - JMT trailhead opening date (currently June 15)
+
+    End date must be less than or equal to:
+    - END_DATE defined at top of script
+    - last date in the JMT report
+    - last report date + MAX_RESERVE_DAYS (currently 168)
+    - JMT trailhead close date (currently September 30)
+
+    :param jmt_report: dictionary of reserved permits (output of get_jmt_report)
+    :param timestamp: timestamp of the last report update
+
+    :return: start date and end date in YYYY-MM-DD format
+    """
+    min_found_date = min(jmt_report)
+    max_found_date = max(jmt_report)
+    report_date = timestamp.date()
+    min_reserve_date = (report_date + timedelta(days=config.MIN_RESERVE_DAYS)).strftime("%Y-%m-%d")
+    max_reserve_date = (report_date + timedelta(days=config.MAX_RESERVE_DAYS)).strftime("%Y-%m-%d")
+    open_date = f"{report_date.year}-{config.OPEN_DATE}"
+    close_date = f"{report_date.year}-{config.CLOSE_DATE}"
+    start_date = max(START_DATE, min_found_date, min_reserve_date, open_date)
+    end_date = min(END_DATE, max_found_date, max_reserve_date, close_date)
+    return start_date, end_date
+
+
+def create_text_report(timestamp: datetime, available_permit_dict: dict, trailheads: dict) -> str:
+    """
+    Convert the dictionary of available permits to a text report with human
+    readable trailhead names. This is the text that will be written to the
+    output file and sent in notifications.
+    """
+    out_tz = pytz.timezone(OUTPUT_TIME_ZONE)
+    timestamp_str = timestamp.astimezone(out_tz).strftime("%Y-%m-%d %-I:%M:%S %p %Z")
+    update_str = f"Report last updated {timestamp_str}.\n"
+    if len(available_permit_dict) == 0:
+        text = f"NO AVAILABLE PERMITS\n\n{update_str}"
+    else:
+        text_list = []
+        for date in available_permit_dict:
+            date_text = f"{date}:"
+            for trailhead_id in available_permit_dict[date]:
+                n = available_permit_dict[date][trailhead_id]
+                trailhead_name = trailheads[trailhead_id]["wpsName"]
+                date_text += f"\n{n} permit{'s' if n != 1 else ''} for {trailhead_name}"
+            text_list.append(date_text)
+
+        text = "\n\n".join(text_list)
+        text += f"\n\n{update_str}"
+        text += f"\nPermit request form: {config.PERMIT_REQUEST_FORM_URL}"
+        text += f"\nPermit office phone: {config.PERMIT_OFFICE_PHONE}"
+
+    return text
+
+
+def decide_whether_to_notify(text: str, permits: dict, timestamp: datetime) -> bool:
+    """
+    Write output file and decide whether to notify. Send notification if all of
+    the following are true:
+    - there are available permits (or NOTIFY_IF_NO_PERMITS is True)
+    - the contents of the output file have changed
+    - the updated happened after MIN_REPORT_DATE
+    """
+    # Detect if output_path has changed. If so, rewrite output.
+    output_has_changed = True
+    if config.OUTPUT_PATH is not None:
+        output_path = pathlib.Path(config.OUTPUT_PATH)
+        if output_path.is_file():
+            previous_text = output_path.read_text()
+            output_has_changed = text != previous_text
+        if output_has_changed:
+            print(f"writing to {output_path.absolute()}")
+            output_path.write_text(text)
+        else:
+            print("no change since last run")
+
+    # determine whether to notify
+    notify = (
+        ((len(permits) > 0) or NOTIFY_IF_NO_PERMITS)
+        and output_has_changed
+        and (config.MIN_REPORT_DATE <= timestamp.strftime("Y-%m-%d"))
+    )
+    return notify
+
+
+def date_range(
+    start: str,
+    end: str,
+    date_format: str = "%Y-%m-%d",
+    inclusive_end: bool = True,
+) -> str:
+    """Return a generator for looping through a range of dates."""
+    start = datetime.strptime(start, date_format)
+    end = datetime.strptime(end, date_format)
+    i = 1 if inclusive_end else 0
+    for n in range(int((end - start).days) + i):
+        yield (start + timedelta(n)).strftime(date_format)
+
+
+def send_telegram_notification(text: str):
+    """
+    Send a notification to the Telegram app. Uses the TELEGRAM_TOKEN and
+    TELEGRAM_FROM_NAME parameters at the top of this script.
+    """
+    payload = {
+        "recipient_token": TELEGRAM_TOKEN,
+        "text": text,
+        "origin": TELEGRAM_FROM_NAME,
+        "options": {
+            "disable_link_previews": True
+        },
+    }
+    r = requests.post(config.TELEGRAM_URL, json=payload)
+    r.raise_for_status()
+
+
+def send_IFTTT_notification(text: str):
+    """
+    Send a notification using your IFTTT applet. Uses the IFTTT_EVENT_NAME and
+    IFTTT_KEY parameters at the top of this script.
+    """
+    report = {
+        "value1": text.replace("\n", "<br />"),
+        "value2": config.PERMIT_OFFICE_PHONE,
+    }
+    url = f"{config.IFTTT_HOSTNAME}/trigger/{IFTTT_EVENT_NAME}/with/key/{IFTTT_KEY}"
+    r = requests.post(url, data=report)
+    r.raise_for_status()
+
+
+# only need the twilio package if we're sending SMS
+if ENABLE_TWILIO:
+    from twilio.rest import Client
+
+
+def send_twilio_notification(
+        text: str,
+        from_phone: str = TWILIO_PHONE_NUMBER,
+        to_phone: Union[str, List[str]] = None,
+):
+    """
+    Send SMS text message using Twilio. Uses the TWILIO_ACCOUNT_SID,
+    TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER, and TWILIO_TO_PHONE parameters at
+    the top of this script.
+
+    :param text: contents of text message
+    :param from_phone: phone number to send message (Twilio phone number)
+    :param to_phone: phone number(s) to receive message
+    """
+    # send SMS message(s)
+    to_phone = to_phone or TWILIO_TO_PHONE
+    to_phone = _force_to_list(to_phone)
+    from_phone = _parse_phone_number(from_phone)
+    client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+    for x in to_phone:
+        client.messages.create(
+            body=text,
+            from_=from_phone,
+            to=_parse_phone_number(x),
+        )
+
+    # report twilio balance
+    balance_data = client.api.v2010.balance.fetch()
+    balance = float(balance_data.balance)
+    currency = balance_data.currency
+    print(f"current twilio balance: {balance} {currency}")
+    if balance < 0.1:
+        warnings.warn(f"twilio balance is running low")
+
+
+def _parse_phone_number(phone_number: str) -> str:
+    """Parse the digits from a string and format as +1xxxxxxxxxx"""
+    phone_number = "".join(filter(str.isdigit, phone_number))
+    if len(phone_number) == 10:
+        phone_number = f"1{phone_number}"
+    return f"+{phone_number}"
+
+
+def _force_to_list(x) -> list:
+    if not isinstance(x, list):
+        x = [x]
+    return x
+
+
+if __name__ == "__main__":
+    main()

--- a/hackjohn.py
+++ b/hackjohn.py
@@ -1,6 +1,7 @@
 """
 Bot to monitor for southbound permit spaces on the John Muir Trail
 Written by Daniel Himmelstein
+Updated for new website in 2021 by Danny Cunningham
 
 Check whether any spaces are available for the
 "Donohue Exit Quota and Trailhead Space Available".

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-beautifulsoup4
-html5lib
-numpy
-pandas>=0.24
-python-dateutil
 requests
+tenacity
+pytz
+2captcha-python
+twilio


### PR DESCRIPTION
Fixes #9. The README has been updated to reflect all of the changes and enhancements described below.

# Core changes

These changes allow hackjohn to work with the new permit website. The major changes to the core code are:
* Use the 2Captcha service to bypass the Recaptcha.
* Use the API endpoints to retrieve permit and trailhead information. It's no longer an HTML table that can be easily scraped, so we have to call the API and then use the quota logic to calculate permit availability.

# Other enhancements

* Add support for Twilio SMS notifications.
* With the Recaptcha and API changes, it became helpful to modularize parts of the code. I ended up rewriting more of the code than I originally expected, but I think the result is more modular and hopefully easier to maintain. (I'm open to restructuring if it would make it easier to use or maintain.)
